### PR TITLE
Security: Fix DOT injection in Graphviz formatter

### DIFF
--- a/formatter/formatter_dot.go
+++ b/formatter/formatter_dot.go
@@ -4,8 +4,11 @@ import (
 	// Used to embed graphviz template file
 	_ "embed"
 	"fmt"
+	"hash/fnv"
+	"strconv"
 	"strings"
 	"text/template"
+	"unicode"
 )
 
 // DotFormatter is used to create Graphviz (dot) format
@@ -73,6 +76,9 @@ func (f *DotFormatter) defineTemplateFunctions(tmpl *template.Template) {
 	tmpl.Funcs(
 		template.FuncMap{
 			"clean_ip":         cleanIP,
+			"dot_id":           dotID,
+			"dot_quote":        dotQuote,
+			"port_node_id":     portNodeID,
 			"port_state_color": portStateColor,
 			"hop_list":         hopList,
 		},
@@ -82,6 +88,34 @@ func (f *DotFormatter) defineTemplateFunctions(tmpl *template.Template) {
 // cleanIP removes dots from IP address to make it possible to use in graphviz as an ID
 func cleanIP(ip string) string {
 	return strings.ReplaceAll(ip, ".", "")
+}
+
+func dotQuote(v string) string {
+	return strconv.Quote(v)
+}
+
+func dotID(v string) string {
+	return dotQuote(dotSafeIdentifier(v))
+}
+
+func portNodeID(hostKey int, port *Port) string {
+	return fmt.Sprintf("srv%d_port_%s_%d", hostKey, dotSafeIdentifier(port.Protocol), port.PortID)
+}
+
+func dotSafeIdentifier(v string) string {
+	var b strings.Builder
+	for _, r := range v {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) || r == '_' {
+			b.WriteRune(r)
+		}
+	}
+	if b.Len() > 0 {
+		return b.String()
+	}
+
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(v))
+	return fmt.Sprintf("x%x", h.Sum64())
 }
 
 // portStateColor returns hexademical color value for state port

--- a/formatter/formatter_dot_test.go
+++ b/formatter/formatter_dot_test.go
@@ -264,17 +264,76 @@ func TestDotFormatter_Format(t *testing.T) {
 			},
 			wantErr: false,
 			validate: func(f *DotFormatter, output string, t *testing.T) {
-				if !strings.Contains(output, "srv0 [label=\"10.10.10.12\", tooltip=\"10.10.10.12\", shape=hexagon, style=filled];") {
+				if !strings.Contains(output, "\"srv0\" [label=\"10.10.10.12\", tooltip=\"10.10.10.12\", shape=hexagon, style=filled];") {
 					t.Error("Does not contain correct sv0")
 				}
 				hops := []string{
-					"hop1921681001 [label=\"\", tooltip=\"192.168.100.1\", shape=circle, height=.12, width=.12, style=filled];",
-					"hop19216811 [label=\"\", tooltip=\"192.168.1.1\", shape=circle, height=.12, width=.12, style=filled];",
+					"\"hop1921681001\" [label=\"\", tooltip=\"192.168.100.1\", shape=circle, height=.12, width=.12, style=filled];",
+					"\"hop19216811\" [label=\"\", tooltip=\"192.168.1.1\", shape=circle, height=.12, width=.12, style=filled];",
 				}
 				for i := range hops {
 					if !strings.Contains(output, hops[i]) {
 						t.Errorf("Could not find hop: %s", hops[i])
 					}
+				}
+			},
+		},
+		{
+			name: "Escapes malicious scan-controlled values",
+			fields: fields{
+				&Config{
+					Writer: &dotMockedWriter{},
+				},
+			},
+			args: args{
+				td: &TemplateData{
+					NMAPRun: NMAPRun{
+						Scanner: `nmap"]; injected [URL="javascript:alert(1)`,
+						Host: []Host{
+							{
+								Port: []Port{
+									{
+										Protocol: `tcp"]; injected [URL="javascript:alert(1)`,
+										PortID:   80,
+										State: PortState{
+											State: `open"]; injected [URL="javascript:alert(1)`,
+										},
+									},
+								},
+								HostAddress: []HostAddress{
+									{
+										Address: `10.0.0.1"]; injected [URL="javascript:alert(1)`,
+									},
+								},
+								Status: HostStatus{
+									State: "up",
+								},
+								Trace: Trace{
+									Hops: []Hop{
+										{
+											IPAddr: `192.0.2.1"]; injected [URL="javascript:alert(1)`,
+										},
+										{
+											IPAddr: "10.0.0.1",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				templateContent: DotTemplate,
+			},
+			wantErr: false,
+			validate: func(f *DotFormatter, output string, t *testing.T) {
+				if strings.Contains(output, `label="nmap"];`) {
+					t.Fatalf("DOT output contains unescaped injection payload: %s", output)
+				}
+				if strings.Contains(output, `URL="javascript:alert(1)"`) {
+					t.Fatalf("DOT output contains injected URL attribute: %s", output)
+				}
+				if !strings.Contains(output, `label="nmap\"]; injected [URL=\"javascript:alert(1)"`) {
+					t.Fatalf("DOT output does not contain escaped scanner label: %s", output)
 				}
 			},
 		},

--- a/formatter/resources/templates/graphviz.tmpl
+++ b/formatter/resources/templates/graphviz.tmpl
@@ -1,25 +1,25 @@
 strict digraph "Scan" {
-    fontname="{{ index .Constants "default_font" }}"
-    node [fontname="{{ index .Constants "default_font" }}", width=.25, height=.375, fontsize=9]
-    edge [fontname="{{ index .Constants "default_font" }}"]
+    fontname={{ dot_quote (index .Constants "default_font") }}
+    node [fontname={{ dot_quote (index .Constants "default_font") }}, width=.25, height=.375, fontsize=9]
+    edge [fontname={{ dot_quote (index .Constants "default_font") }}]
     layout={{ index .Constants "layout" }}
 
-    scanner [label="{{ .NMAPRun.Scanner }}", shape=hexagon, style=filled];
+    {{ dot_id "scanner" }} [label={{ dot_quote .NMAPRun.Scanner }}, shape=hexagon, style=filled];
 
     {{- $hops := .NMAPRun.AllHops }}
     {{ range $key, $value := $hops -}}
-    hop{{ clean_ip $key }} [label="", tooltip="{{ $key }}", shape=circle, height=.12, width=.12, style=filled];
+    {{ dot_id (printf "hop%s" $key) }} [label="", tooltip={{ dot_quote $key }}, shape=circle, height=.12, width=.12, style=filled];
     {{ end }}
 
     {{ range $key, $value := .NMAPRun.Host -}}
-    srv{{ $key }} [label="{{ $value.JoinedAddresses "/" }}", tooltip="{{ $value.JoinedAddresses "/" }}", shape=hexagon, style=filled];
+    {{ dot_id (printf "srv%d" $key) }} [label={{ dot_quote ($value.JoinedAddresses "/") }}, tooltip={{ dot_quote ($value.JoinedAddresses "/") }}, shape=hexagon, style=filled];
     {{ range $portKey, $portValue := $value.Port }}
-    srv{{ $key }}_port_{{ $portValue.Protocol }}_{{ $portValue.PortID }} [label="{{ $portValue.Protocol }}/{{ $portValue.PortID }} ({{ $portValue.State.State }})", tooltip="{{ $portValue.Protocol }}/{{ $portValue.PortID }} ({{ $portValue.State.State }})", shape=underline, width=.12, height=.12, fontsize=8, color="{{ port_state_color $portValue }}"];
-    srv{{ $key }} -> srv{{ $key }}_port_{{ $portValue.Protocol }}_{{ $portValue.PortID }} [arrowhead=none];
+    {{ dot_id (port_node_id $key $portValue) }} [label={{ dot_quote (printf "%s/%d (%s)" $portValue.Protocol $portValue.PortID $portValue.State.State) }}, tooltip={{ dot_quote (printf "%s/%d (%s)" $portValue.Protocol $portValue.PortID $portValue.State.State) }}, shape=underline, width=.12, height=.12, fontsize=8, color={{ dot_quote (port_state_color $portValue) }}];
+    {{ dot_id (printf "srv%d" $key) }} -> {{ dot_id (port_node_id $key $portValue) }} [arrowhead=none];
     {{ end -}}
 
     {{ range $hopSource, $hopTarget := hop_list $value.Trace.Hops "scanner" "srv" $key }}
-    {{ clean_ip $hopSource }} -> {{ clean_ip $hopTarget }} [arrowhead=none];
+    {{ dot_id $hopSource }} -> {{ dot_id $hopTarget }} [arrowhead=none];
     {{- end }}
 
     {{ end }}


### PR DESCRIPTION
- Add DOT string quoting helpers
- Sanitize node/edge identifiers
- Add regression test for injection attempts

CVSS: 6.1 (Medium)